### PR TITLE
Merge 18_buildreport-saves into main: Add automatic option to save build reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GroupByTexturesEditorWindow, find and show all 'Textures' and 'Materials' in use in the scene, grouped by the Texture format and size.
 - LocationsEditorWindow, configure and open commonly used paths. These are saved per project so they can be shared among the team easily.
 - Add extra info option, to log out all tracked performance recorders and light count, when a threshold is exceeded.
+- Add json format save of build reports for later consumption.

--- a/Packages/Clarity/Editor/ProfileRecorderAlerts.cs
+++ b/Packages/Clarity/Editor/ProfileRecorderAlerts.cs
@@ -16,7 +16,7 @@ public class ProfileRecorderAlerts
         public bool HardError;
     }
     
-    [UserSetting("Extra Context", "Enbaled")]
+    [UserSetting("Extra Context", "Enabled")]
     private static UserSetting<bool> ExtraLogContextEnabled = new UserSetting<bool>(ClarityEditorSettings.Instance, $"warningLimits.{nameof(ExtraLogContextEnabled)}", true, SettingsScope.Project);
     [UserSetting()]
     private static UserSetting<ThresholdValues> SetPassLimit = new UserSetting<ThresholdValues>(ClarityEditorSettings.Instance, $"warningLimits.{nameof(SetPassLimit)}", new ThresholdValues(), SettingsScope.Project);

--- a/Packages/Clarity/Editor/SaveBuildReport.cs
+++ b/Packages/Clarity/Editor/SaveBuildReport.cs
@@ -56,11 +56,12 @@ public class SaveBuildReport : IPostprocessBuildWithReport
         //convert the steps to a table
         for (int i = 0; i < report.steps.Length; i++)
         {
-            serialisableReport.steps.Add(new SerialisableBuildStep(i, report.steps[i]));
-            for (int j = 0; j < report.steps[i].messages.Length; j++)
+            var step = report.steps[i];
+            serialisableReport.steps.Add(new SerialisableBuildStep(i, step));
+            var messages = step.messages;
+            for (int j = 0; j < messages.Length; j++)
             {
-                var message = report.steps[i].messages[j];
-                var buildStepMessage = new SerialisableBuildStepMessage(i, message);
+                var buildStepMessage = new SerialisableBuildStepMessage(i, messages[j]);
                 serialisableReport.stepMessages.Add(buildStepMessage);
             }
         }
@@ -68,13 +69,22 @@ public class SaveBuildReport : IPostprocessBuildWithReport
         //convert the packed assets to a table
         for (int i = 0; i < report.packedAssets.Length; i++)
         {
-            serialisableReport.packedAssets.Add(new SerialisablePackedAssets(i, report.packedAssets[i]));
-            for (int j = 0; j < report.packedAssets[i].contents.Length; j++)
+            var packedAsset = report.packedAssets[i];
+            serialisableReport.packedAssets.Add(new SerialisablePackedAssets(i, packedAsset));
+            var packedAssetInfo = report.packedAssets[i].contents;
+            for (int j = 0; j < packedAssetInfo.Length; j++)
             {
-                var content = report.packedAssets[i].contents[j];
-                var packedAssetInfo = new SerialisablePackedAssetInfo(i, content);
-                serialisableReport.packedAssetInfo.Add(packedAssetInfo);
+                var content = packedAssetInfo[j];
+                serialisableReport.packedAssetInfo.Add(new SerialisablePackedAssetInfo(i, content));
             }
+        }
+
+        //convert the files to a table
+        var files = report.GetFiles();
+        for (int i = 0; i < files.Length; i++)
+        {
+            var file = files[i];
+            serialisableReport.files.Add(new SerialisableBuildFile(file));
         }
 
         //convert all to json
@@ -92,6 +102,7 @@ public class SaveBuildReport : IPostprocessBuildWithReport
         public List<SerialisablePackedAssetInfo> packedAssetInfo = new();
         public List<SerialisableBuildStep> steps = new();
         public List<SerialisableBuildStepMessage> stepMessages = new();
+        public List<SerialisableBuildFile> files = new();
     }
 
     [Serializable]
@@ -196,6 +207,23 @@ public class SaveBuildReport : IPostprocessBuildWithReport
             BuildStepIndex = i;
             content = message.content;
             type = message.type.ToString();
+        }
+    }
+
+    [Serializable]
+    public class SerialisableBuildFile
+    {
+        public long id;
+        public string Path;
+        public ulong Size;
+        public string role;
+
+        public SerialisableBuildFile(BuildFile file)
+        {
+            id = file.id;
+            Path = file.path;
+            Size = file.size;
+            role = file.role;
         }
     }
 }

--- a/Packages/Clarity/Editor/SaveBuildReport.cs
+++ b/Packages/Clarity/Editor/SaveBuildReport.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+public class SaveBuildReport : IPostprocessBuildWithReport
+{
+    public int callbackOrder => 0;
+
+    public void OnPostprocessBuild(BuildReport report)
+    {
+        DoTheThing(report);
+    }
+
+#if UNITY_6000_0_OR_NEWER
+    [MenuItem("Edit/Clarity/Save Last Build Report")]
+    public static void SaveReport()
+    {
+        DoTheThing(BuildReport.GetLatestReport());
+    }
+#endif
+
+    public static void DoTheThing(BuildReport report)
+    {
+        string path = Path.Combine(Application.dataPath, "../BuildReports");
+        if (!Directory.Exists(path))
+        {
+            Directory.CreateDirectory(path);
+        }
+        var fileExt = ".json";
+        var fileName = Path.Combine(path, "BuildReport_" + report.summary.buildEndedAt.ToString("yyyy-MM-dd_HH-mm-ss") + fileExt);
+        var contents = ConvertReportToFile(report);
+
+        File.WriteAllText(fileName, contents);
+    }
+
+    private static string ConvertReportToFile(BuildReport report)
+    {
+        var serialisableReport = new SerialisableBuildReport();
+
+        //convert the summary to a table
+        serialisableReport.summary = new SerialisableBuildReportSummary(report.summary);
+
+        //convert the steps to a table
+        for (int i = 0; i < report.steps.Length; i++)
+        {
+            serialisableReport.steps.Add(new SerialisableBuildStep(i, report.steps[i]));
+            for (int j = 0; j < report.steps[i].messages.Length; j++)
+            {
+                var message = report.steps[i].messages[j];
+                var buildStepMessage = new SerialisableBuildStepMessage(i, message);
+                serialisableReport.stepMessages.Add(buildStepMessage);
+            }
+        }
+
+        //convert the packed assets to a table
+        for (int i = 0; i < report.packedAssets.Length; i++)
+        {
+            serialisableReport.packedAssets.Add(new SerialisablePackedAssets(i, report.packedAssets[i]));
+            for (int j = 0; j < report.packedAssets[i].contents.Length; j++)
+            {
+                var content = report.packedAssets[i].contents[j];
+                var packedAssetInfo = new SerialisablePackedAssetInfo(i, content);
+                serialisableReport.packedAssetInfo.Add(packedAssetInfo);
+            }
+        }
+
+        //convert all to json
+        var jsonString = JsonUtility.ToJson(serialisableReport, true);
+
+        return jsonString;
+    }
+
+    [Serializable]
+    //and then use something like https://products.aspose.app/cells/conversion/json-to-xlsx to convert it to a spreadsheet
+    public class SerialisableBuildReport
+    {
+        public SerialisableBuildReportSummary summary;
+        public List<SerialisablePackedAssets> packedAssets = new();
+        public List<SerialisablePackedAssetInfo> packedAssetInfo = new();
+        public List<SerialisableBuildStep> steps = new();
+        public List<SerialisableBuildStepMessage> stepMessages = new();
+    }
+
+    [Serializable]
+    public class SerialisableBuildReportSummary
+    {
+        public DateTime StartTime;
+        public DateTime EndedTime;
+        public string BuildType;
+        public string GUID;
+        public string Options;
+        public string OutputPath;
+        public string Platform;
+        public string PlatformGroup;
+        public string Result;
+        public int TotalErrors;
+        public ulong TotalSize;
+        public TimeSpan TotalTime;
+        public int TotalWarnings;
+
+        public SerialisableBuildReportSummary(BuildSummary summary)
+        {
+            StartTime = summary.buildStartedAt;
+            EndedTime = summary.buildEndedAt;
+            //BuildType = summary.;
+            GUID = summary.guid.ToString();
+            Options = summary.options.ToString();
+            OutputPath = summary.outputPath;
+            Platform = summary.platform.ToString();
+            PlatformGroup = summary.platformGroup.ToString();
+            Result = summary.result.ToString();
+            TotalErrors = summary.totalErrors;
+            TotalSize = summary.totalSize;
+            TotalTime = summary.totalTime;
+            TotalWarnings = summary.totalWarnings;
+        }
+    }
+
+    [Serializable]
+    public class SerialisablePackedAssets
+    {
+        public int index;
+        public ulong overhead;
+        public string path;
+
+        public SerialisablePackedAssets(int i, PackedAssets packedAssets)
+        {
+            index = i;
+            overhead = packedAssets.overhead;
+            path = packedAssets.shortPath;
+        }
+    }
+
+    [Serializable]
+    public class SerialisablePackedAssetInfo
+    {
+        public int PackedAssetsIndex;
+        public long id;
+        public ulong offset;
+        public ulong size;
+        public string Guid;
+        public string path;
+        public string Type;
+
+        public SerialisablePackedAssetInfo(int i, PackedAssetInfo content)
+        {
+            PackedAssetsIndex = i;
+            id = content.id;
+            offset = content.offset;
+            size = content.packedSize;
+            Guid = content.sourceAssetGUID.ToString();
+            path = content.sourceAssetPath;
+            Type = content.type.ToString();
+        }
+    }
+
+    [Serializable]
+    public class SerialisableBuildStep
+    {
+        public int index;
+        public string name;
+        public int depth;
+        public TimeSpan duration;
+
+        public SerialisableBuildStep(int i, BuildStep step)
+        {
+            index = i;
+            name = step.name;
+            depth = step.depth;
+            duration = step.duration;
+        }
+    }
+
+    [Serializable]
+    public class SerialisableBuildStepMessage
+    {
+        public int BuildStepIndex;
+        public string content;
+        public string type;
+
+        public SerialisableBuildStepMessage(int i, BuildStepMessage message)
+        {
+            BuildStepIndex = i;
+            content = message.content;
+            type = message.type.ToString();
+        }
+    }
+}

--- a/Packages/Clarity/Editor/SaveBuildReport.cs
+++ b/Packages/Clarity/Editor/SaveBuildReport.cs
@@ -21,18 +21,18 @@ public class SaveBuildReport : IPostprocessBuildWithReport
     public void OnPostprocessBuild(BuildReport report)
     {
         if (BuildReportSaveEnabled)
-            DoTheThing(report);
+            GenerateAndSave(report);
     }
 
 #if UNITY_6000_0_OR_NEWER
     [MenuItem("Edit/Clarity/Save Last Build Report")]
     public static void SaveReport()
     {
-        DoTheThing(BuildReport.GetLatestReport());
+        GenerateAndSave(BuildReport.GetLatestReport());
     }
 #endif
 
-    public static void DoTheThing(BuildReport report)
+    public static void GenerateAndSave(BuildReport report)
     {
         string path = Path.Combine(Application.dataPath, BuildReportFolder);
         if (!Directory.Exists(path))
@@ -126,7 +126,9 @@ public class SaveBuildReport : IPostprocessBuildWithReport
         {
             StartTime = summary.buildStartedAt;
             EndedTime = summary.buildEndedAt;
-            //BuildType = summary.;
+#if UNITY_6000_0_OR_NEWER
+            BuildType = summary.buildType.ToString();
+#endif
             GUID = summary.guid.ToString();
             Options = summary.options.ToString();
             OutputPath = summary.outputPath;

--- a/Packages/Clarity/Editor/SaveBuildReport.cs
+++ b/Packages/Clarity/Editor/SaveBuildReport.cs
@@ -1,18 +1,27 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using Actuator;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
+using UnityEditor.SettingsManagement;
 using UnityEngine;
 
 public class SaveBuildReport : IPostprocessBuildWithReport
 {
     public int callbackOrder => 0;
 
+    [UserSetting("Build Reports", "Enabled")]
+    private static UserSetting<bool> BuildReportSaveEnabled = new UserSetting<bool>(ClarityEditorSettings.Instance, $"saveBuildReport.{nameof(BuildReportSaveEnabled)}", true, SettingsScope.Project);
+    [UserSetting("Build Reports", "Location")]
+    private static UserSetting<string> BuildReportFolder = new UserSetting<string>(ClarityEditorSettings.Instance, $"saveBuildReport.{nameof(BuildReportFolder)}", "../BuildReports", SettingsScope.Project);
+
+
     public void OnPostprocessBuild(BuildReport report)
     {
-        DoTheThing(report);
+        if (BuildReportSaveEnabled)
+            DoTheThing(report);
     }
 
 #if UNITY_6000_0_OR_NEWER
@@ -25,7 +34,7 @@ public class SaveBuildReport : IPostprocessBuildWithReport
 
     public static void DoTheThing(BuildReport report)
     {
-        string path = Path.Combine(Application.dataPath, "../BuildReports");
+        string path = Path.Combine(Application.dataPath, BuildReportFolder);
         if (!Directory.Exists(path))
         {
             Directory.CreateDirectory(path);

--- a/Packages/Clarity/Editor/SaveBuildReport.cs.meta
+++ b/Packages/Clarity/Editor/SaveBuildReport.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94c0861bb10143449a6f882e94831e87
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ https://github.com/ActuatorDigital/Clarity.git?path=Packages/Clarity
 Clarity adds the following Menu Item(s).
 
 - `Edit/Clarity/Find All Lights` - Sets the Hierarchy to filter by type `light`.
+- `Edit/Clarity/Save Last Build Report` - Converts last unity build report to json format. Saved in location defined in editor preferences.
 
 Clarity provides the following editor window(s).
 


### PR DESCRIPTION
<!-- title as 'Merge <Source identifier> into <Parent identifier>: <Source description>'
 E.g. Merge 27_header-styles into main: Update Header colours to match style guide -->
## Summary
<!-- A clear and concise summary of changes made. 1-2 sentences. -->
Stores the unity build report info in more usable json format for each build.

## Details
<!-- A more in-depth listing of changes made. If none, remove this section. 
This section is to aid the reviewer by increasing their understanding of what was done and
how they can review the changes. If the changes are trivial, remove the section. -->
Does not close but is part of #18 
Being json seems useful but doesn't actually get into a spreadsheet very easily, so we might want converts or just change the format in the first place.

## Project Health
<!-- This section is especially important when merging into main or similar. 
All relevant items that are not ticked should be addressed in either the Details or Additional context section.
Remove any lines that do not apply. -->
- [x] Readme updated.
- [x] Changelog updated.